### PR TITLE
Fixed bug when testing models

### DIFF
--- a/scripts/rnf/hyperopt.py
+++ b/scripts/rnf/hyperopt.py
@@ -97,7 +97,7 @@ def objective(
 
     # 9. Test model
     results = trainer.test(
-        model, ds.val_dataloader(), ckpt_path=checkpoint_callback.best_model_path
+        ds.val_dataloader(), ckpt_path=checkpoint_callback.best_model_path
     )
 
     # not actually results on test set - key stems from test_epoch_end

--- a/scripts/rnf/main.py
+++ b/scripts/rnf/main.py
@@ -122,7 +122,7 @@ def main(cfg: DictConfig):
 
     # 9. Test model
     results = trainer.test(
-        model, ds.test_dataloader(), ckpt_path=checkpoint_callback.best_model_path
+        ds.test_dataloader(), ckpt_path=checkpoint_callback.best_model_path
     )
 
     log.info(results)


### PR DESCRIPTION
If passing both a model and checkpoint path, the path is ignored and
evaluation uses the model. Thus, instead of using the best model the
last model was used.