### PR TITLE
Bug fix when using train_subtrees SST

### DIFF
--- a/text_classification/datasets/sst.py
+++ b/text_classification/datasets/sst.py
@@ -64,12 +64,13 @@ def SSTDataset(
 
     # define a parser to format each example - use partial to supply additional
     # arguments
-    parser = partial(parse_line_tree, subtrees=train_subtrees)
+    train_parser = partial(parse_line_tree, subtrees=train_subtrees)
+    val_test_parser = partial(parse_line_tree, subtrees=False)
 
     # get data from all files using defined parser
-    train = get_data_from_file(os.path.join(root, name, dir_name, "train.txt"), parser)
-    val = get_data_from_file(os.path.join(root, name, dir_name, "dev.txt"), parser)
-    test = get_data_from_file(os.path.join(root, name, dir_name, "test.txt"), parser)
+    train = get_data_from_file(os.path.join(root, name, dir_name, "train.txt"), train_parser)
+    val = get_data_from_file(os.path.join(root, name, dir_name, "dev.txt"), val_test_parser)
+    test = get_data_from_file(os.path.join(root, name, dir_name, "test.txt"), val_test_parser)
 
     # data: List of lists. Using map function to filter, tokenize and convert to list of Examples
     map_f = partial(


### PR DESCRIPTION
Subtrees would also be loaded for val and test sets - changed this so
that val and test sets don't load subtrees