### PR TITLE
Fix spacy tokenizer

### DIFF
--- a/text_classification/tokenizers/tokenizers.py
+++ b/text_classification/tokenizers/tokenizers.py
@@ -25,4 +25,4 @@ class SpacyTokenizer(BaseTokenizer):
 
     def __call__(self, x: str) -> List:
         tokens = self.nlp(x)
-        return [token.lower_ for token in tokens if not token.is_punct]
+        return [token.lower_ for token in tokens]


### PR DESCRIPTION
Spacy tokenizer was silently removing punctuation tokens, causing
problems when all tokens from an example were removed.