### PR TITLE
Fixed bug in RNF model

### DIFF
--- a/text_classification/models/rnf.py
+++ b/text_classification/models/rnf.py
@@ -33,7 +33,7 @@ class TimeDistributedLSTM(pl.LightningModule):
                 x,
                 dim=self.time_axis,
                 index=torch.tensor([i], device=self.device).long(),
-            ).squeeze()
+            ).squeeze(1)
 
             _, (hidden_t, _) = self.lstm(x_input)
 
@@ -145,12 +145,11 @@ class RNF(BaseClassifier):
         # FILTER_WIDTH, EMBED_DIM]
 
         lstm_outputs = self.time_lstm(lstm_inputs)
-        # lstm_outputs: [BATCH SIZE, LONGEST SEQ - FILTER_WIDTH + 1,
-        # FILTER_WIDTH, LSTM_OUT]
+        # lstm_outputs: [BATCH SIZE, LONGEST SEQ - FILTER_WIDTH + 1, LSTM_OUT]
 
         lstm_outputs = F.max_pool1d(
             lstm_outputs.permute(0, 2, 1), kernel_size=lstm_outputs.shape[1]
-        ).squeeze(1)
+        ).squeeze()
         # lstm_outputs: [BATCH SIZE, LSTM_OUT]
 
         outputs = self.fc(lstm_outputs)

--- a/text_classification/models/rnf.py
+++ b/text_classification/models/rnf.py
@@ -150,7 +150,7 @@ class RNF(BaseClassifier):
 
         lstm_outputs = F.max_pool1d(
             lstm_outputs.permute(0, 2, 1), kernel_size=lstm_outputs.shape[1]
-        ).squeeze()
+        ).squeeze(1)
         # lstm_outputs: [BATCH SIZE, LSTM_OUT]
 
         outputs = self.fc(lstm_outputs)


### PR DESCRIPTION
Error would arise if batch_size is 1 - for example at the end of a
dataloader. This was caused by a squeeze() statement that also squeezed
the batch dimension - changed this to squeeze only the time dimension.